### PR TITLE
chore: Bump Dockerfile base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.7-alpine as builder
+FROM golang:1.23.1-alpine as builder
 
 # TARGETPLATFORM should be one of linux/amd64 or linux/arm64.
 ARG TARGETPLATFORM="linux/amd64"


### PR DESCRIPTION
To be compatible with go upgrade.